### PR TITLE
Improve CSS naming and clean unused rules

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -181,46 +181,24 @@ h5,
   font-weight: 300;
 }
 
-.section__subtitle {
-  margin-bottom: 1em;
-  font-size: var(--fs-h3);
-  color: var(--color-darker);
-}
-
-.section__subtitle--intro,
-.section__subtitle--about,
-.section__subtitle--project {
-  background: var(--color-accent_light);
-  padding: 0.25em;
-  margin-top: -0.5rem;
-  font-weight: 400;
-  height: 2rem;
-  color: var(--color-light);
-}
-
-@media (min-width: 800px) {
-  .section__subtitle--intro {
-    margin-top: -1rem;
-  }
-}
-
 /* ------  Repeating features/elements -------- */
-
-/* .section__title--services::after,
-.section__title--work::after,
-.section__title--contact::after {
-  content: "";
-  display: block;
-  width: 4em;
-  height: 6px;
-  opacity: 80%;
-  margin: 0.1em auto 0.5em auto;
-  background-color: var(--color-accent);
-} */
 
 .text-block {
   max-width: 65ch;
   margin-inline: auto;
+}
+
+.color-bar-thick,
+.color-bar-thin {
+  background: var(--color-accent_light);
+  padding: 0.25em;
+  margin-top: -0.5rem;
+  height: 2rem;
+  width: 100%;
+}
+
+.color-bar-thin {
+  height: 0.5rem;
 }
 
 .dividing-line {
@@ -484,11 +462,6 @@ At this point the three lines are stacked on each other
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-}
-
-.section__subtitle--intro {
-  text-align: right;
-  width: 100%;
 }
 
 /* ------  footer -------- */

--- a/blog/index.html
+++ b/blog/index.html
@@ -71,7 +71,7 @@
         <h1 class="section__title section__title--intro">
           <span class="bold-text">Blog Posts</span>
         </h1>
-        <div class="section__subtitle section__subtitle--intro accent-text" style="margin-top: -0.5rem ">
+        <div class="color-bar-thick" style="margin-top: -0.5rem ">
           </>
         </div>
         <div class="intro__spacer"></div>

--- a/blog/introduction.html
+++ b/blog/introduction.html
@@ -71,7 +71,7 @@
         <h1 class="section__title section__title--intro">
           <span class="bold-text">An Introduction</span>
         </h1>
-        <div class="section__subtitle section__subtitle--intro accent-text" style="margin-top: -0.5rem ">
+        <div class="color-bar-thick" style="margin-top: -0.5rem ">
           </>
         </div>
         <div class="intro__spacer"></div>

--- a/blog/struggles.html
+++ b/blog/struggles.html
@@ -71,7 +71,7 @@
         <h1 class="section__title section__title--intro">
           <span class="bold-text">On Struggle</span>
         </h1>
-        <div class="section__subtitle section__subtitle--intro accent-text" style="margin-top: -0.5rem ">
+        <div class="color-bar-thick" style="margin-top: -0.5rem ">
           </>
         </div>
         <div class="intro__spacer"></div>

--- a/blog/toolhunt.html
+++ b/blog/toolhunt.html
@@ -71,7 +71,7 @@
         <h1 class="section__title section__title--intro">
           <span class="bold-text">Introducing Toolhunt</span>
         </h1>
-        <div class="section__subtitle section__subtitle--intro accent-text" style="margin-top: -0.5rem ">
+        <div class="color-bar-thick" style="margin-top: -0.5rem ">
           </>
         </div>
         <div class="intro__spacer"></div>

--- a/contact.html
+++ b/contact.html
@@ -71,7 +71,7 @@
         <h1 class="section__title section__title--intro">
           <span class="bold-text">Contact Me</span>
         </h1>
-        <div class="section__subtitle section__subtitle--intro accent-text">
+        <div class="color-bar-thick">
           </>
         </div>
         <div class="intro__spacer"></div>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
       <h1 class="section__title section__title--intro">
         Hi, I'm <span class="bold-text">Nicole Barnabee</span>
       </h1>
-      <div class="section__subtitle section__subtitle--intro accent-text">
+      <div class="color-bar-thick">
         </>
       </div>
       <div class="intro__spacer"></div>


### PR DESCRIPTION
I had once had text inside the elements that were given the "subtitle" class, but eventually the "subtitles" were downgraded to, in effect, color bars.  So why still call them subtitles?

I also removed some unused declarations.